### PR TITLE
query and search UI support for subject and coverage fields

### DIFF
--- a/app/assets/javascripts/search/search_result_draw_query.js
+++ b/app/assets/javascripts/search/search_result_draw_query.js
@@ -19,7 +19,9 @@ jQuery(document).ready(function($) {
 			lang: 'Language',
 			fuz_q: 'Search Term Fuzziness',
 			fuz_t: 'Title Fuzziness',
-			pages: 'Pages of'
+			pages: 'Pages of',
+			subject: 'Subject',
+			coverage: 'Coverage'
 		};
 		if (types[key])
 			return types[key];
@@ -91,6 +93,8 @@ jQuery(document).ready(function($) {
 			searchTypes.push(['Owner', 'r_own']);
 		}
 		searchTypes.push(['Year (YYYY)', 'y']);
+		searchTypes.push(['Subject', 'subject']);
+		searchTypes.push(['Coverage', 'coverage']);
 		var selectTypeOptions = "";
 		for (var i = 0; i < searchTypes.length; i++)
 			selectTypeOptions += window.pss.createHtmlTag("option", {value: searchTypes[i][1] }, searchTypes[i][0]);

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -97,7 +97,7 @@ class SearchController < ApplicationController
 	   constraints = []
 	   return constraints if query.blank?
 
-	   legal_constraints = [ 'q', 'f', 'o', 'g', 'a', 't', 'aut', 'ed', 'pub', 'r_art', 'r_own', 'fuz_q', 'fuz_t', 'y', 'lang', 'doc_type', 'discipline', 'fuz_q', 'fuz_t' ]
+	   legal_constraints = [ 'q', 'f', 'o', 'g', 'a', 't', 'aut', 'ed', 'pub', 'r_art', 'r_own', 'fuz_q', 'fuz_t', 'y', 'lang', 'doc_type', 'discipline', 'fuz_q', 'fuz_t', 'subject', 'coverage' ]
 	   @searchable_roles.each { |role|
 		   legal_constraints.push(role[0])
 	   }
@@ -106,7 +106,7 @@ class SearchController < ApplicationController
 	   query.each { |key, val|
 		   found_federation = true if key == 'f'
 		   if legal_constraints.include?(key) && val.present?
-			   if key == 'q' || key == 't' || key == 'aut' || key == 'pub' || key == 'ed' || key == 'r_own' || key == 'r_art'
+			   if key == 'q' || key == 't' || key == 'aut' || key == 'pub' || key == 'ed' || key == 'r_own' || key == 'r_art' || key == 'subject' || key == 'coverage'
 				   val = process_q_param(val)
 			   end
 			   # if we were passed fuzzy constraints, make sure that the corresponding other value is set

--- a/app/views/search/_add_constraint_form.html.erb
+++ b/app/views/search/_add_constraint_form.html.erb
@@ -153,7 +153,7 @@
              </td>
            </tr>
         <% end %>
-        <% if SKIN.upcase == 'MESA' %>
+        <% if ['MESA', 'NEAR'].include? SKIN.upcase %>
             <tr><td>Role:</td><td><%= select_tag( :search_role_type, options_from_collection_for_select([ ['', '(Select a role)'] ] + @searchable_roles, :first, :last), :class => 'search_role_type' ) %>
            <input name="search_role" id="search_role" type="text" class="search_entry_box_short" placeholder="Please select a role."/>
             </td>
@@ -177,6 +177,8 @@
            </tr>
         <% end %>
         <tr><td>Year (YYYY):</td><td><input id="search_year" name="y" type="text" class="search_entry_box" <%= "value='#{@yphrs}'" if @yphrs %> /></td></tr>
+				<tr><td>Subject:</td><td><input id="search_subject" name="subject" type="text" class="search_entry_box" <%= "value='#{@sphrs}'" if @sphrs %> /></td></tr>
+				<tr><td>Coverage:</td><td><input id="search_coverage" name="coverage" type="text" class="search_entry_box" <%= "value='#{@cphrs}'" if @cphrs %> /></td></tr>
         <tr><td colspan="3" style="text-align: right;"><input id="search_submit2" type="submit" value="Search" /></td></tr>
     </table>
 	</form>

--- a/app/views/search/_constraints.html.erb
+++ b/app/views/search/_constraints.html.erb
@@ -97,6 +97,8 @@
                   <% @searchable_roles.each do |role| %>
                     <option><%= role[1] %></option>
                   <% end %>
+                  <option>Subject</option>
+                  <option>Coverage</option>
               <% else %>
                   <option>Author</option>
                   <option>Editor</option>

--- a/config/deploy.example.rb
+++ b/config/deploy.example.rb
@@ -6,6 +6,7 @@
 # cap edge_sro
 # cap edge_estc
 # cap edge_gla
+# cap edge_near
 # cap prod_nines
 # cap prod_18th
 # cap prod_mesa
@@ -13,6 +14,7 @@
 # cap prod_sro
 # cap prod_estc
 # cap prod_gla
+# cap prod_near
 
 require 'rvm/capistrano'
 require 'bundler/capistrano'
@@ -28,7 +30,8 @@ else
    puts "***"
 end
 
-set :repository, "git://github.com/collex/collex.git"
+# set :repository, "git://github.com/collex/collex.git"
+set :repository, "git://github.com/ARC-code/collex.git"
 set :scm, "git"
 set :branch, "master"
 set :deploy_via, :remote_cache
@@ -49,13 +52,15 @@ task :menu do
       '5' => { name: "cap edge_sro", computer: 'edge', skin: 'sro' },
       'e' => { name: "cap edge_estc", computer: 'edge', skin: 'estc' },
       'g' => { name: "cap edge_gla", computer: 'edge', skin: 'gla' },
+      'n' => { name: "cap edge_near", computer: 'edge', skin: 'gla' },
       '6' => { name: "cap prod_nines", computer: 'prod', skin: 'nines' },
       '7' => { name: "cap prod_18th", computer: 'prod', skin: '18th' },
       '8' => { name: "cap prod_mesa", computer: 'prod', skin: 'mesa' },
       '9' => { name: "cap prod_modnets", computer: 'prod', skin: 'modnets' },
       'S' => { name: "cap prod_sro", computer: 'prod', skin: 'sro' },
       'E' => { name: "cap prod_estc", computer: 'prod', skin: 'estc' },
-      'G' => { name: "cap prod_gla", computer: 'prod', skin: 'gla' }
+      'G' => { name: "cap prod_gla", computer: 'prod', skin: 'gla' },
+      'N' => { name: "cap prod_near", computer: 'prod', skin: 'near' }
    }
 
    tasks.each { |key, value|
@@ -137,6 +142,11 @@ task :edge_gla do
    set_application('edge', 'gla')
 end
 
+desc "Run tasks to update edge NEAR environment."
+task :edge_near do
+   set_application('edge', 'near')
+end
+
 desc "Run tasks to update production NINES environment."
 task :prod_nines do
    set_application('prod', 'nines')
@@ -170,6 +180,11 @@ end
 desc "Run tasks to update production GLA environment."
 task :prod_gla do
    set_application('prod', 'gla')
+end
+
+desc "Run tasks to update production NEAR environment."
+task :prod_near do
+   set_application('prod', 'near')
 end
 
 namespace :passenger do
@@ -225,6 +240,7 @@ after :edge_modnets, 'deploy'
 after :edge_sro, 'deploy'
 after :edge_estc, 'deploy'
 after :edge_gla, 'deploy'
+after :edge_near, 'deploy'
 after :prod_nines, 'deploy'
 after :prod_18th, 'deploy'
 after :prod_mesa, 'deploy'
@@ -232,6 +248,7 @@ after :prod_modnets, 'deploy'
 after :prod_sro, 'deploy'
 after :prod_estc, 'deploy'
 after :prod_gla, 'deploy'
+after :prod_near, 'deploy'
 after :deploy, "deploy:migrate"
 
 after "deploy:stop",    "delayed_job:stop"
@@ -281,12 +298,18 @@ task :edge_estc_setup do
    set_application('edge', 'estc')
 end
 after :edge_estc_setup, 'deploy:setup'
-   
+
 desc "Set up the edge GLA server."
 task :edge_gla_setup do
    set_application('edge', 'gla')
 end
 after :edge_gla_setup, 'deploy:setup'
+
+desc "Set up the edge NEAR server."
+task :edge_near_setup do
+   set_application('edge', 'near')
+end
+after :edge_near_setup, 'deploy:setup'
 
 desc "Set up the prod nines server."
 task :prod_nines_setup do
@@ -323,12 +346,18 @@ task :prod_estc_setup do
    set_application('prod', 'estc')
 end
 after :prod_estc_setup, 'deploy:setup'
-   
+
 desc "Set up the prod GLA server."
 task :prod_gla_setup do
    set_application('prod', 'gla')
 end
 after :prod_gla_setup, 'deploy:setup'
+
+desc "Set up the prod NEAR server."
+task :prod_near_setup do
+   set_application('prod', 'near')
+end
+after :prod_near_setup, 'deploy:setup'
 
 desc "Set up the edge server's config."
 task :setup_config do


### PR DESCRIPTION
### What does this PR do?
Adds search support for 'subject' and 'coverage' fields to Collex's search interface. Also updates Capistrano configuration to support the new NEAR node.

### What issues does it address?
Closes #3, addresses #4, closes #6 

### How to test
- Visit the search page of the staging instance at http://edge.near-american.org/search
- Confirm that 'subject' and 'coverage' fields appear alongside the other advanced search options.
- Perform a search (temporarily, the site will search from the NINES federation) and confirm that 'subject' and 'coverage' also appear in the dropdown list of fields when adding a search parameter in the search results page.