### PR TITLE
Add button to generate permalink and single-record search view mode

### DIFF
--- a/app/assets/javascripts/search/result_row_popup.js
+++ b/app/assets/javascripts/search/result_row_popup.js
@@ -1,12 +1,12 @@
 //------------------------------------------------------------------------
 //    Copyright 2009 Applied Research in Patacriticism and the University of Virginia
-//    
+//
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
 //    You may obtain a copy of the License at
-//  
+//
 //        http://www.apache.org/licenses/LICENSE-2.0
-//  
+//
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@
 /*global ForumLicenseDisplay */
 /*global document */
 /*global submitForm, submitFormWithConfirmation */
-/*extern collapseAllItems, toggleItemExpand, ResultRowDlg, StartDiscussionWithObject, bulkCollect, bulkUncollect, bulkTag, bulk_checked, doAddTag, doAddToExhibit, doAnnotation, doCollect, doRemoveCollect, doRemoveTag, encodeForUri, expandAllItems, realLinkToEditorLink, removeHidden, tagFinishedUpdating, toggleAllBulkCollectCheckboxes */
+/*extern collapseAllItems, toggleItemExpand, ResultRowDlg, StartDiscussionWithObject, bulkCollect, bulkUncollect, bulkTag, bulk_checked, doAddTag, doAddToExhibit, doShowPermalink, doAnnotation, doCollect, doRemoveCollect, doRemoveTag, encodeForUri, expandAllItems, realLinkToEditorLink, removeHidden, tagFinishedUpdating, toggleAllBulkCollectCheckboxes */
 
 ///////////////////////////////////////////////////////////////////////////
 
@@ -57,7 +57,7 @@ var ResultRowDlg = Class.create({
 		//var This = this;
 		var dlg = null;
 		var obj = '';
-		
+
 		// private functions
 		var ajax_params = extra_button_data;
 		ajax_params.uri = uri;
@@ -82,7 +82,7 @@ var ResultRowDlg = Class.create({
 			};
 			serverRequest({ url: populate_action, params: ajax_params, onSuccess: onSuccess});
 		};
-		
+
 		// privileged functions
 		var dlgLayout = {
 				page: 'layout',
@@ -91,7 +91,7 @@ var ResultRowDlg = Class.create({
 					[ { rowClass: 'gd_last_row' }, { button: 'Cancel', callback: GeneralDialog.cancelCallback, isDefault: true } ]
 				]
 			};
-		
+
 		var params = { this_id: "result_row_dlg", pages: [ dlgLayout ], body_style: "result_row_dlg", row_style: "result_row_row", title: "Object Details" };
 		dlg = new GeneralDialog(params);
 		//dlg.changePage('layout', null);
@@ -146,13 +146,13 @@ function bulkCollect(autocompleteUrl)
       initialize: function ( params ) {
          var title = params.title;
          var addAction = params.addAction;
-         var skipAction = params.skipAction; 
+         var skipAction = params.skipAction;
          var dlg = null;
          var id='tag[name]';
          var msg = 'Your objects have been collected. Would you like to add a tag to the batch?';
          var prompt = 'Tag:';
          var hint = 'Add multiple tags by separating them with a comma (e.g. painting, visual_art)';
-         
+
          // privileged functions
          this.add = function(event, addParams)
          {
@@ -165,24 +165,24 @@ function bulkCollect(autocompleteUrl)
          {
             skipParams.dlg.cancel();
             skipAction();
-         };  
-  
+         };
+
          var dlgLayout = {
             page: 'layout',
-            rows: 
+            rows:
             [
                [{text: msg, klass: 'gd_text_input_dlg_label'}],
-               [ { text: prompt, klass: 'gd_text_input_dlg_label' }, 
+               [ { text: prompt, klass: 'gd_text_input_dlg_label' },
                  { autocomplete: id, klass: 'new_exhibit_autocomplete', url: autocompleteUrl, token: ','} ],
-               [ {text: hint, id: "gd_postExplanation", klass: 'gd_text_input_help'}], 
-               [ { rowClass: 'gd_last_row'}, 
-                 {button: "Add Tags", callback: this.add, isDefault: true}, 
+               [ {text: hint, id: "gd_postExplanation", klass: 'gd_text_input_help'}],
+               [ { rowClass: 'gd_last_row'},
+                 {button: "Add Tags", callback: this.add, isDefault: true},
                  {button: 'Skip Tags', callback: this.skip} ]
             ]
          };
          dlgLayout.rows.push();
-         
-         var dlgparams = {this_id: "gd_text_input_dlg", pages: [ dlgLayout ], body_style: "gd_message_box_dlg", row_style: "gd_message_box_row", 
+
+         var dlgparams = {this_id: "gd_text_input_dlg", pages: [ dlgLayout ], body_style: "gd_message_box_dlg", row_style: "gd_message_box_row",
             title: title, focus: GeneralDialog.makeId(id)};
          dlg = new GeneralDialog(dlgparams);
          dlg.center();
@@ -202,9 +202,9 @@ function bulkCollect(autocompleteUrl)
 	}
 
 	if (has_one)
-	{  
+	{
 	   var tagAction = function(tagName)
-      {   
+      {
          var ele = $('bulk_tag_text');
          ele.value = tagName;
          submitForm("bulk_collect_form", "/results/bulk_collect", "post");
@@ -213,7 +213,7 @@ function bulkCollect(autocompleteUrl)
       {
          submitForm("bulk_collect_form", "/results/bulk_collect", "post");
       };
-      
+
       new BulkTagDlg({title:"Tag Selections", addAction: tagAction, skipAction:noTagAction});
 	}
 	else
@@ -226,20 +226,20 @@ function bulkUncollect()
 {
 	var checkboxes = Form.getInputs('bulk_collect_form', 'checkbox');
 	var has_one = false;
-	for (var i = 0; i < checkboxes.length; i++) 
+	for (var i = 0; i < checkboxes.length; i++)
 	{
 		var checkbox = checkboxes[i];
-		if (checkbox.checked) 
+		if (checkbox.checked)
 		{
 			has_one = true;
 			break;
 		}
 	}
-	
+
 	if (has_one)
 	{
 			submitFormWithConfirmation({id:"bulk_collect_form", action:"/results/bulk_uncollect",
-        title:"Remove Selected Objects from Collection?", 
+        title:"Remove Selected Objects from Collection?",
         message:"Are you sure you wish to remove the selected objects from your collection?"});
 	}
 	else
@@ -303,7 +303,7 @@ function toggleItemExpand()
       col.style.display = 'none';
       collapseAllItems();
    }
-   
+
 }
 
 function doCollect(partial, uri, row_num, row_id, is_logged_in, hasEdit)
@@ -580,3 +580,8 @@ function doAddToExhibit(partial, uri, index, row_id, my_collex_url)
 	}
 }
 
+function doShowPermalink(uri) {
+	var url = History.getBaseUrl() + "search?uri=" + window.escape(uri) + '&perm';
+	new MessageBoxDlg('Permalink', '<input class="link_dlg_input_long permalink_field" onClick="this.select();" type="text" value="' + url + '"></input>');
+	document.getElementsByClassName('permalink_field')[0].select();
+}

--- a/app/assets/javascripts/search/search_result_draw_media_block.js
+++ b/app/assets/javascripts/search/search_result_draw_media_block.js
@@ -36,7 +36,7 @@ jQuery(document).ready(function($) {
 	function createImageBlock(index, hit) {
 		var check = "";
 		var isLoggedIn = window.collex.currentUserId && window.collex.currentUserId > 0;
-		if (isLoggedIn)
+		if (isLoggedIn && !window.collex.permalinkMode)
 			check = window.pss.createHtmlTag("input", { 'type': 'checkbox', 'id': "bulk_collect_"+index, 'name': "bulk_collect["+index+"]", 'value': hit.uri });
 		var image = thumbnailImageTag(hit);
 		var icons = "";
@@ -61,13 +61,14 @@ jQuery(document).ready(function($) {
 		var discuss = window.pss.createHtmlTag("button", { 'class': 'discuss' }, "Discuss");
 		var exhibit = isCollected ? window.pss.createHtmlTag("button", { 'class': 'exhibit' }, "Exhibit") : '';
 		var typewright = window.collex.hasTypewright && hit.typewright ? window.pss.createHtmlTag("button", { 'class': 'edit log-in-first-link', 'data-login-prompt': "Please log in to begin editing" }, "Edit") : '';
+		var permalink = window.pss.createHtmlTag("button", { 'class': 'permalink' }, "Permalink");
 		var pages = "";
 		if ( window.collex.hasPageSearch ) {
            if ( hit.has_pages ) {
               pages = window.pss.createHtmlTag("button", { 'class': 'page-search' }, "All Pages");
            }
 		}
-		return window.pss.createHtmlTag("div", { 'class': 'search_result_buttons' }, collect+uncollect+discuss+exhibit+typewright+pages);
+		return window.pss.createHtmlTag("div", { 'class': 'search_result_buttons' }, collect+uncollect+discuss+exhibit+typewright+pages+permalink);
 	}
 
 	function createZoteraTitle(obj) {
@@ -140,7 +141,7 @@ jQuery(document).ready(function($) {
 			return "";
 
 		var klass = "row";
-		if (startHidden) {
+		if (startHidden && !window.collex.permalinkMode) {
 			klass += ' hidden';
 			needShowMoreLink = true;
 		}

--- a/app/assets/javascripts/search/search_row_actions.js
+++ b/app/assets/javascripts/search/search_row_actions.js
@@ -40,6 +40,12 @@ jQuery(document).ready(function($) {
 		doEditDocument( params.isLoggedIn, tw_url );
 	});
 
+	body.on("click", ".search_result_buttons .permalink", function (e) {
+		var params = setup(e, this);
+		doShowPermalink(params.uri);
+		return false;
+	});
+
 	body.on("click", ".search-result .uri_link", function (e) {
 		jQuery(this).next().toggle();
 		return false;
@@ -51,4 +57,3 @@ jQuery(document).ready(function($) {
    });
 
 });
-

--- a/app/assets/stylesheets/result_row.css.scss
+++ b/app/assets/stylesheets/result_row.css.scss
@@ -248,3 +248,14 @@ span.tooltip:hover span.result_row_tooltip {
 	color: black;
 }
 }
+
+.permalink-mode {
+	div.search_result_header {
+		font-size: 1.8em;
+		line-height: 30px;
+		margin-bottom: 0.5em;
+	}
+	div.search_result_data_container {
+		font-size: 1.2em;
+	}
+}

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -97,7 +97,7 @@ class SearchController < ApplicationController
 	   constraints = []
 	   return constraints if query.blank?
 
-	   legal_constraints = [ 'q', 'f', 'o', 'g', 'a', 't', 'aut', 'ed', 'pub', 'r_art', 'r_own', 'fuz_q', 'fuz_t', 'y', 'lang', 'doc_type', 'discipline', 'fuz_q', 'fuz_t', 'subject', 'coverage' ]
+	   legal_constraints = [ 'q', 'f', 'o', 'g', 'a', 't', 'aut', 'ed', 'pub', 'r_art', 'r_own', 'fuz_q', 'fuz_t', 'y', 'lang', 'doc_type', 'discipline', 'fuz_q', 'fuz_t', 'subject', 'coverage', 'uri' ]
 	   @searchable_roles.each { |role|
 		   legal_constraints.push(role[0])
 	   }
@@ -106,7 +106,7 @@ class SearchController < ApplicationController
 	   query.each { |key, val|
 		   found_federation = true if key == 'f'
 		   if legal_constraints.include?(key) && val.present?
-			   if key == 'q' || key == 't' || key == 'aut' || key == 'pub' || key == 'ed' || key == 'r_own' || key == 'r_art' || key == 'subject' || key == 'coverage'
+			   if key == 'q' || key == 't' || key == 'aut' || key == 'pub' || key == 'ed' || key == 'r_own' || key == 'r_art' || key == 'subject' || key == 'coverage' || key == 'uri'
 				   val = process_q_param(val)
 			   end
 			   # if we were passed fuzzy constraints, make sure that the corresponding other value is set
@@ -172,6 +172,7 @@ class SearchController < ApplicationController
 		 ["role_TRL", "Translator"],
 		 ["role_WDE", "Wood Engraver"]
 	 ]
+   @permalink_mode = params.has_key? 'perm'
 	 return true
    end
 

--- a/app/views/results/_results.html.erb
+++ b/app/views/results/_results.html.erb
@@ -52,6 +52,7 @@
 	<% else %>
 	  window.collex.collected = {};
 	<% end %>
+	window.collex.permalinkMode = <%= @permalink_mode %>
 </script>
 <div class="search-results">
 

--- a/app/views/results/_results_with_all_functionality.html.erb
+++ b/app/views/results/_results_with_all_functionality.html.erb
@@ -15,19 +15,20 @@
     # limitations under the License.
     # ---------------------------------------------------------------------------- -%>
 <%# results_with_all_functionality params: string mode, string title, array results, int page, int num_pages, string controller, string action -%>
-<div class="page_header"><%# = render( :partial => 'results/result_count' ) if controller == 'tagXXX' %>
-   <% controller = 'search'  if controller == 'collex' %>
-   <% curr_selection = @collected_sort_by.present? ? @collected_sort_by : '' %>
-   <% curr_selection_direction = @collected_sort_by_direction.present? ? @collected_sort_by_direction : '' %>
-   <% options = (controller == 'search' ? [["Relevancy", 'rel'], ["Title", 'title'], ["Name", 'author'], ["Date",'year']] : (controller == 'tag' ? [["Title", 'title'], ["Author",'author'], ["Date",'year'], ["Resource",'a']] : [["Date Collected", ''], ["Title", 'title'], ["Author",'author'], ["Date",'year'], ["Resource",'a']])) -%>
-   <%= render( :partial => 'results/sort_by', :locals => { :options => options, :curr_selection => curr_selection, :curr_selection_direction => curr_selection_direction }) %>
-   <%= title %></div>
-<hr class="search_results_hr" />
-
-<div class="expand_all_link"><%= render( :partial => 'results/bulkcollect', :locals => {:mode => mode, :page => page} ) %></div>
-<div class="search_results_pages">
-   <div class="pagination"></div>
-</div>
+<% unless @permalink_mode %>
+  <div class="page_header"><%# = render( :partial => 'results/result_count' ) if controller == 'tagXXX' %>
+     <% controller = 'search'  if controller == 'collex' %>
+     <% curr_selection = @collected_sort_by.present? ? @collected_sort_by : '' %>
+     <% curr_selection_direction = @collected_sort_by_direction.present? ? @collected_sort_by_direction : '' %>
+     <% options = (controller == 'search' ? [["Relevancy", 'rel'], ["Title", 'title'], ["Name", 'author'], ["Date",'year']] : (controller == 'tag' ? [["Title", 'title'], ["Author",'author'], ["Date",'year'], ["Resource",'a']] : [["Date Collected", ''], ["Title", 'title'], ["Author",'author'], ["Date",'year'], ["Resource",'a']])) -%>
+     <%= render( :partial => 'results/sort_by', :locals => { :options => options, :curr_selection => curr_selection, :curr_selection_direction => curr_selection_direction }) %>
+     <%= title %></div>
+  <hr class="search_results_hr" />
+  <div class="expand_all_link"><%= render( :partial => 'results/bulkcollect', :locals => {:mode => mode, :page => page} ) %></div>
+  <div class="search_results_pages">
+     <div class="pagination"></div>
+  </div>
+<% end %>
 
 <form name="bulk_collect_form" id="bulk_collect_form">
    <input type="hidden" id="page" name="page" value="<%= page %>" />
@@ -39,8 +40,10 @@
 </div>
 
 <div class="clear_both"></div>
+<% unless @permalink_mode %>
 <hr class="search_results_hr" />
 <div class="expand_all_link"><%= render( :partial => 'results/bulkcollect', :locals => {:mode => mode, :page => page}  ) %></div>
 <div class="search_results_pages">
    <div class="pagination"></div>
 </div>
+<% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -36,7 +36,7 @@
 	<div class="search_error_message" style="display:none;"></div>
 	<div class="left_column ajax-style">
 		<%= render(:partial => 'add_constraint_form') %>
-		<div class="has-results" style="display:none;">
+		<div class="has-results<%= @permalink_mode ? ' permalink-mode' : '' %>" style="display:none;">
 			<div class="page_header">
 			   <% if SKIN == "sro" %>
 			      <button class="new_search" value="New Search">New Search</button>

--- a/config/initializers/abstract_mysql2_adapter.rb
+++ b/config/initializers/abstract_mysql2_adapter.rb
@@ -1,0 +1,5 @@
+# see http://stackoverflow.com/questions/21075515/creating-tables-and-problems-with-primary-key-in-rails
+
+class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+  NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+end


### PR DESCRIPTION
### What does this PR do?
Adds a "Permalink" button to the controls shown alongside records in a search results collection. When clicked, the button will trigger a popup showing a URL that can be used as a permalink to retrieve only that record via its URI. The URL will include a special `perm` parameter that will cause the search results display to increase font size in the record and hide features unneeded for a single result.

### What issues does it address?
Closes #11 

### How to test
- Using the staging instance of the NEAR node as a test case, go to http://edge.near-american.org/search and perform a search that yields at least one result
- Each result should show a "Permalink" button among the other buttons to the right
- Click on the button to display the permalink popup. The popup should contain a field with a URL that has been selected for easy copying
- Copy the URL and paste it into your browser to access the permalink. You should see a similar display as the search results page, but showing only the record for which you generated the permalink. The font size in this record should be larger than normal, and all metadata fields should be displayed rather than hidden behind a "show more" link