### PR TITLE
Add place of publication subfields

### DIFF
--- a/app/assets/javascripts/search/search_result_draw_media_block.js
+++ b/app/assets/javascripts/search/search_result_draw_media_block.js
@@ -284,6 +284,7 @@ jQuery(document).ready(function($) {
 		html += createResultContentItem('multiple_item', 'Genre:', obj.genre, true);
 		html += createResultContentItem('multiple_item', 'Discipline:', obj.discipline, true);
 		html += createResultContentItem('multiple_item', 'Subject:', obj.subject, true);
+    html += createResultContentItem('multiple_item', $('body').hasClass('federation-near') || $('body').hasClass('federation-collex') ? 'Place of Pub.:' : 'Coverage', obj.coverage, true);
 		html += createResultContentItem('single_item', 'Exhibit&nbsp;type:', obj.exhibit_type, false);
 		html += createResultContentItem('single_item', 'License:', obj.license, false);
 

--- a/app/assets/javascripts/search/search_result_draw_query.js
+++ b/app/assets/javascripts/search/search_result_draw_query.js
@@ -21,8 +21,15 @@ jQuery(document).ready(function($) {
 			fuz_t: 'Title Fuzziness',
 			pages: 'Pages of',
 			subject: 'Subject',
-			coverage: 'Coverage'
 		};
+		if (body.hasClass('federation-near') || body.hasClass('federation-collex')) {
+			types.coverage = 'Place of Publication';
+			types.publication_state = 'Publication State';
+			types.publication_city = 'Publication City';
+		}
+		else {
+			types.coverage = 'Coverage';
+		}
 		if (types[key])
 			return types[key];
 		return key;
@@ -94,7 +101,14 @@ jQuery(document).ready(function($) {
 		}
 		searchTypes.push(['Year (YYYY)', 'y']);
 		searchTypes.push(['Subject', 'subject']);
-		searchTypes.push(['Coverage', 'coverage']);
+    if (body.hasClass('federation-near') || body.hasClass('federation-collex')) {
+      searchTypes.push(['Place of Publication', 'coverage']);
+      searchTypes.push(['Publication State', 'publication_state']);
+      searchTypes.push(['Publication City', 'publication_city']);
+    }
+    else {
+      searchTypes.push(['Coverage', 'coverage']);
+    }
 		var selectTypeOptions = "";
 		for (var i = 0; i < searchTypes.length; i++)
 			selectTypeOptions += window.pss.createHtmlTag("option", {value: searchTypes[i][1] }, searchTypes[i][0]);

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -97,10 +97,23 @@ class SearchController < ApplicationController
 	   constraints = []
 	   return constraints if query.blank?
 
-	   legal_constraints = [ 'q', 'f', 'o', 'g', 'a', 't', 'aut', 'ed', 'pub', 'r_art', 'r_own', 'fuz_q', 'fuz_t', 'y', 'lang', 'doc_type', 'discipline', 'fuz_q', 'fuz_t', 'subject', 'coverage', 'uri' ]
+	   legal_constraints = [ 'q', 'f', 'o', 'g', 'a', 't', 'aut', 'ed', 'pub', 'r_art', 'r_own', 'fuz_q', 'fuz_t', 'y', 'lang', 'doc_type', 'discipline', 'fuz_q', 'fuz_t', 'subject', 'coverage', 'publication_country', 'publication_state', 'publication_city', 'uri' ]
 	   @searchable_roles.each { |role|
 		   legal_constraints.push(role[0])
 	   }
+
+     if query.has_key?('publication_state') && query.has_key?('publication_city')
+       coverage = query.has_key?('coverage') ? query['coverage'] + " " : "";
+       coverage = coverage + "\"#{query['publication_state']} #{query['publication_city']}\""
+       query['coverage'] = coverage
+     end
+
+     # prevent users from seeing error when trying to use MARC-style delimiters
+     ['subject', 'coverage'].each do |key|
+       if query.has_key?(key)
+         query[key] = query[key].gsub(/--/, " ")
+       end
+     end
 
 	   found_federation = false
 	   query.each { |key, val|

--- a/app/views/search/_add_constraint_form.html.erb
+++ b/app/views/search/_add_constraint_form.html.erb
@@ -178,7 +178,13 @@
         <% end %>
         <tr><td>Year (YYYY):</td><td><input id="search_year" name="y" type="text" class="search_entry_box" <%= "value='#{@yphrs}'" if @yphrs %> /></td></tr>
 				<tr><td>Subject:</td><td><input id="search_subject" name="subject" type="text" class="search_entry_box" <%= "value='#{@sphrs}'" if @sphrs %> /></td></tr>
-				<tr><td>Coverage:</td><td><input id="search_coverage" name="coverage" type="text" class="search_entry_box" <%= "value='#{@cphrs}'" if @cphrs %> /></td></tr>
+        <% if SKIN.upcase == 'NEAR' || SKIN.upcase == 'COLLEX' %>
+           <tr><td>Place of Publication:</td><td><input id="search_coverage" name="coverage" type="text" class="search_entry_box" <%= "value='#{@cphrs}'" if @cphrs %> /></td></tr>
+           <tr><td><div style="padding-left: 20px;">State:</div></td><td><input id="search_publication_state" name="publication_state" type="text" class="search_entry_box" /></td></tr>
+           <tr><td><div style="padding-left: 20px;">City:</div></td><td><input id="search_publication_city" name="publication_city" type="text" class="search_entry_box" /></td></tr>
+        <% else %>
+				   <tr><td>Coverage:</td><td><input id="search_coverage" name="coverage" type="text" class="search_entry_box" <%= "value='#{@cphrs}'" if @cphrs %> /></td></tr>
+        <% end %>
         <tr><td colspan="3" style="text-align: right;"><input id="search_submit2" type="submit" value="Search" /></td></tr>
     </table>
 	</form>


### PR DESCRIPTION
### What does this PR do?
Adds search fields for place of publication state and city, enabled only for the NEAR skin. Changes "coverage" to "place of publication" in UI views for the NEAR skin. Values entered for state and city of publication, when both are present, are aggregated into the coverage field in the backend so that only results with the specified city and state in the same original coverage string will be returned (e.g. searching for state:Massachusetts and city:Philadelphia should not return results).

Also adds query processing to prevent errors when users enter the "--" delimiter, a conventional syntax in MARC-derived records.

### What issues does it address?
Closes #19 

### How to test
At http://edge.near-american.org, go to the Search page and confirm the Place of Publication field and subfields for State and City appear in the form. Adding values to either State of City will cause a "Search error... unknown parameter" message since these fields have not yet been added to the catalog's Solr schema. However, they should appear as options in the "Search Term" dropdown on the resulting page after performing an initial search.